### PR TITLE
Fixes jshint gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ var AUTOPREFIXER_BROWSERS = [
 
 // Lint JavaScript
 gulp.task('jshint', function () {
-  return gulp.src('app/scripts/**/*.js')
+  return gulp.src(['app/scripts/**/*.js', '!app/scripts/bower_components/**'])
     .pipe(reload({stream: true, once: true}))
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))


### PR DESCRIPTION
Excludes `app/scripts/bower_components/` folder from being checked
by the gulp jshint task